### PR TITLE
Pin Grafana to 11.1.3

### DIFF
--- a/config-files/docker-compose.yaml
+++ b/config-files/docker-compose.yaml
@@ -1,12 +1,10 @@
-version: '3.8'
-
 services:
   smtp:
     image: ixdotai/smtp:v0.5.2
     ports:
       - 127.0.0.1:25:25
   grafana:
-    image: grafana/grafana:${GRAFANA_VERSION:-10.3.1}
+    image: grafana/grafana:${GRAFANA_VERSION:-11.1.3}
     ports:
       - "3000:3000"
     environment:

--- a/config-files/grafana/provisioning/datasources/datasource.yaml
+++ b/config-files/grafana/provisioning/datasources/datasource.yaml
@@ -11,6 +11,3 @@ datasources:
     orgId: 1
     basicAuth: false
     isDefault: true
-    jsonData:
-      tlsAuth: false
-      tlsAuthWithCACert: false

--- a/kubernetes/grafana.yaml
+++ b/kubernetes/grafana.yaml
@@ -42,7 +42,7 @@ spec:
           - 0
       containers:
         - name: grafana
-          image: grafana/grafana:latest
+          image: grafana/grafana:11.1.3
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/terraform/docker-compose.yaml
+++ b/terraform/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   smtp:
     image: ixdotai/smtp:v0.5.2


### PR DESCRIPTION
Pin Grafana to `11.1.3` + previous TH addition (https://github.com/grafana/provisioning-alerting-examples/commit/fa2b04ab6fdd1d5138ec48ddcf3f025740034638)